### PR TITLE
Updated SGA_Protege_OWL.owl

### DIFF
--- a/SGA_Protege_OWL.owl
+++ b/SGA_Protege_OWL.owl
@@ -1,171 +1,186 @@
 <?xml version="1.0"?>
-<Ontology xmlns="http://www.w3.org/2002/07/owl#"
+<rdf:RDF xmlns="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#"
      xml:base="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     ontologyIRI="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern">
-    <Prefix name="" IRI="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#"/>
-    <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
-    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
-    <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
-    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
-    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
-    <Declaration>
-        <Class IRI="#Value"/>
-    </Declaration>
-    <Declaration>
-        <Class IRI="#Attribute"/>
-    </Declaration>
-    <Declaration>
-        <ObjectProperty IRI="#hasContextRelation"/>
-    </Declaration>
-    <Declaration>
-        <ObjectProperty IRI="#hasType"/>
-    </Declaration>
-    <Declaration>
-        <Class IRI="#SpatialInformationObject"/>
-    </Declaration>
-    <Declaration>
-        <Class IRI="#Type"/>
-    </Declaration>
-    <Declaration>
-        <Class IRI="#ContextualizedRelation"/>
-    </Declaration>
-    <Declaration>
-        <ObjectProperty IRI="#hasAttribute"/>
-    </Declaration>
-    <Declaration>
-        <ObjectProperty IRI="#refersTo"/>
-    </Declaration>
-    <Declaration>
-        <Class IRI="#SpatialObject"/>
-    </Declaration>
-    <Declaration>
-        <ObjectProperty IRI="#represents"/>
-    </Declaration>
-    <Declaration>
-        <ObjectProperty IRI="#hasValue"/>
-    </Declaration>
-    <DisjointClasses>
-        <Class IRI="#Attribute"/>
-        <Class IRI="#ContextualizedRelation"/>
-    </DisjointClasses>
-    <DisjointClasses>
-        <Class IRI="#Attribute"/>
-        <Class IRI="#ContextualizedRelation"/>
-        <Class IRI="#SpatialObject"/>
-    </DisjointClasses>
-    <DisjointClasses>
-        <Class IRI="#Attribute"/>
-        <Class IRI="#SpatialInformationObject"/>
-        <Class IRI="#Type"/>
-        <Class IRI="#Value"/>
-    </DisjointClasses>
-    <DisjointClasses>
-        <Class IRI="#ContextualizedRelation"/>
-        <Class IRI="#SpatialInformationObject"/>
-        <Class IRI="#Type"/>
-        <Class IRI="#Value"/>
-    </DisjointClasses>
-    <DisjointClasses>
-        <Class IRI="#SpatialInformationObject"/>
-        <Class IRI="#SpatialObject"/>
-        <Class IRI="#Type"/>
-        <Class IRI="#Value"/>
-    </DisjointClasses>
-    <InverseObjectProperties>
-        <ObjectProperty IRI="#hasContextRelation"/>
-        <ObjectProperty IRI="#refersTo"/>
-    </InverseObjectProperties>
-    <ObjectPropertyDomain>
-        <ObjectProperty IRI="#hasAttribute"/>
-        <Class IRI="#SpatialInformationObject"/>
-    </ObjectPropertyDomain>
-    <ObjectPropertyDomain>
-        <ObjectProperty IRI="#hasContextRelation"/>
-        <Class IRI="#SpatialInformationObject"/>
-    </ObjectPropertyDomain>
-    <ObjectPropertyDomain>
-        <ObjectProperty IRI="#hasType"/>
-        <Class IRI="#Attribute"/>
-    </ObjectPropertyDomain>
-    <ObjectPropertyDomain>
-        <ObjectProperty IRI="#hasType"/>
-        <Class IRI="#ContextualizedRelation"/>
-    </ObjectPropertyDomain>
-    <ObjectPropertyDomain>
-        <ObjectProperty IRI="#hasValue"/>
-        <Class IRI="#Attribute"/>
-    </ObjectPropertyDomain>
-    <ObjectPropertyDomain>
-        <ObjectProperty IRI="#hasValue"/>
-        <Class IRI="#ContextualizedRelation"/>
-    </ObjectPropertyDomain>
-    <ObjectPropertyDomain>
-        <ObjectProperty IRI="#refersTo"/>
-        <Class IRI="#ContextualizedRelation"/>
-    </ObjectPropertyDomain>
-    <ObjectPropertyDomain>
-        <ObjectProperty IRI="#represents"/>
-        <Class IRI="#SpatialInformationObject"/>
-    </ObjectPropertyDomain>
-    <ObjectPropertyRange>
-        <ObjectProperty IRI="#hasAttribute"/>
-        <Class IRI="#Attribute"/>
-    </ObjectPropertyRange>
-    <ObjectPropertyRange>
-        <ObjectProperty IRI="#hasContextRelation"/>
-        <Class IRI="#ContextualizedRelation"/>
-    </ObjectPropertyRange>
-    <ObjectPropertyRange>
-        <ObjectProperty IRI="#hasType"/>
-        <Class IRI="#Type"/>
-    </ObjectPropertyRange>
-    <ObjectPropertyRange>
-        <ObjectProperty IRI="#hasValue"/>
-        <Class IRI="#Value"/>
-    </ObjectPropertyRange>
-    <ObjectPropertyRange>
-        <ObjectProperty IRI="#refersTo"/>
-        <Class IRI="#SpatialInformationObject"/>
-    </ObjectPropertyRange>
-    <ObjectPropertyRange>
-        <ObjectProperty IRI="#represents"/>
-        <Class IRI="#SpatialObject"/>
-    </ObjectPropertyRange>
-    <AnnotationAssertion>
-        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
-        <IRI>#Attribute</IRI>
-        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value.</Literal>
-    </AnnotationAssertion>
-    <AnnotationAssertion>
-        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
-        <IRI>#ContextualizedRelation</IRI>
-        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value. ContextualizedRelation must have exactly one Value and exactly one Type.  ContextualizedRelation refers to at least one SpatialInformationObject.</Literal>
-    </AnnotationAssertion>
-    <AnnotationAssertion>
-        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
-        <IRI>#SpatialInformationObject</IRI>
-        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">A SpatialInformationObject may have Attribute and may have ContextualizedRelation. Since Attributes and ContextualizedRelations have different descriptions in different data schema, these model classes were also chosen to work for any of the schemas used by our domain tools.</Literal>
-    </AnnotationAssertion>
-    <AnnotationAssertion>
-        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
-        <IRI>#SpatialObject</IRI>
-        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">An InformationObject represents exactly one SpatialObject.</Literal>
-    </AnnotationAssertion>
-    <AnnotationAssertion>
-        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
-        <IRI>#Type</IRI>
-        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">Our use of hasType makes the model more amenable to resolving the large variation of schema differences that exist; instead of subclassing we consider types to be instances of individuals so that we are not burdened by the decision to say that something is a subtype or not. Doing so would cause more hierarchical confusion instead of help in terms of its application. Nevertheless, having typing through properties does not preclude us from adding in the function of such a hierarchy later on.</Literal>
-    </AnnotationAssertion>
-    <AnnotationAssertion>
-        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
-        <IRI>#refersTo</IRI>
-        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">The refersTo relation is an inverse of hasContextRelation.</Literal>
-    </AnnotationAssertion>
-</Ontology>
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasAttribute -->
+
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasAttribute">
+        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasContextRelation -->
+
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasContextRelation">
+        <owl:inverseOf rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#refersTo"/>
+        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasType -->
+
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasType">
+        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
+        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasValue -->
+
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasValue">
+        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
+        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#refersTo -->
+
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#refersTo">
+        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+        <rdfs:comment xml:lang="en">The refersTo relation is an inverse of hasContextRelation.</rdfs:comment>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#represents -->
+
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#represents">
+        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute -->
+
+    <owl:Class rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute">
+        <owl:disjointWith rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+        <rdfs:comment xml:lang="en">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation -->
+
+    <owl:Class rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation">
+        <rdfs:comment xml:lang="en">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value. ContextualizedRelation must have exactly one Value and exactly one Type.  ContextualizedRelation refers to at least one SpatialInformationObject.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject -->
+
+    <owl:Class rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject">
+        <rdfs:comment xml:lang="en">A SpatialInformationObject may have Attribute and may have ContextualizedRelation. Since Attributes and ContextualizedRelations have different descriptions in different data schema, these model classes were also chosen to work for any of the schemas used by our domain tools.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject -->
+
+    <owl:Class rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject">
+        <rdfs:comment xml:lang="en">An InformationObject represents exactly one SpatialObject.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type -->
+
+    <owl:Class rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type">
+        <rdfs:comment xml:lang="en">Our use of hasType makes the model more amenable to resolving the large variation of schema differences that exist; instead of subclassing we consider types to be instances of individuals so that we are not burdened by the decision to say that something is a subtype or not. Doing so would cause more hierarchical confusion instead of help in terms of its application. Nevertheless, having typing through properties does not preclude us from adding in the function of such a hierarchy later on.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value -->
+
+    <owl:Class rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // General axioms
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
+            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
+        </owl:members>
+    </rdf:Description>
+</rdf:RDF>
 
 
 

--- a/SGA_Protege_OWL.owl
+++ b/SGA_Protege_OWL.owl
@@ -93,7 +93,6 @@
     <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute -->
 
     <owl:Class rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute">
-        <owl:disjointWith rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
         <rdfs:comment xml:lang="en">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value.</rdfs:comment>
     </owl:Class>
     
@@ -150,30 +149,6 @@
         <owl:members rdf:parseType="Collection">
             <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
             <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
-            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject"/>
-        </owl:members>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-        <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
-            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
-            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
-            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
-        </owl:members>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-        <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
-            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
-            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
-            <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
-        </owl:members>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-        <owl:members rdf:parseType="Collection">
             <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
             <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject"/>
             <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>

--- a/SGA_Protege_OWL.owl
+++ b/SGA_Protege_OWL.owl
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-
-
-<!DOCTYPE Ontology [
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY xml "http://www.w3.org/XML/1998/namespace" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-]>
-
-
 <Ontology xmlns="http://www.w3.org/2002/07/owl#"
      xml:base="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -16,30 +6,17 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      ontologyIRI="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern">
-    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
-    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
-    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
+    <Prefix name="" IRI="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#"/>
     <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
-    <Declaration>
-        <Class IRI="#Attribute"/>
-    </Declaration>
-    <Declaration>
-        <Class IRI="#ContextualizedRelation"/>
-    </Declaration>
-    <Declaration>
-        <Class IRI="#SpatialObject"/>
-    </Declaration>
-    <Declaration>
-        <Class IRI="#SpatialRepresentationObject"/>
-    </Declaration>
-    <Declaration>
-        <Class IRI="#Type"/>
-    </Declaration>
+    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+    <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
+    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
+    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
     <Declaration>
         <Class IRI="#Value"/>
     </Declaration>
     <Declaration>
-        <ObjectProperty IRI="#hasAttribute"/>
+        <Class IRI="#Attribute"/>
     </Declaration>
     <Declaration>
         <ObjectProperty IRI="#hasContextRelation"/>
@@ -48,13 +25,28 @@
         <ObjectProperty IRI="#hasType"/>
     </Declaration>
     <Declaration>
-        <ObjectProperty IRI="#hasValue"/>
+        <Class IRI="#SpatialInformationObject"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#Type"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#ContextualizedRelation"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasAttribute"/>
     </Declaration>
     <Declaration>
         <ObjectProperty IRI="#refersTo"/>
     </Declaration>
     <Declaration>
+        <Class IRI="#SpatialObject"/>
+    </Declaration>
+    <Declaration>
         <ObjectProperty IRI="#represents"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasValue"/>
     </Declaration>
     <DisjointClasses>
         <Class IRI="#Attribute"/>
@@ -67,33 +59,33 @@
     </DisjointClasses>
     <DisjointClasses>
         <Class IRI="#Attribute"/>
-        <Class IRI="#SpatialRepresentationObject"/>
+        <Class IRI="#SpatialInformationObject"/>
         <Class IRI="#Type"/>
         <Class IRI="#Value"/>
     </DisjointClasses>
     <DisjointClasses>
         <Class IRI="#ContextualizedRelation"/>
-        <Class IRI="#SpatialRepresentationObject"/>
+        <Class IRI="#SpatialInformationObject"/>
         <Class IRI="#Type"/>
         <Class IRI="#Value"/>
     </DisjointClasses>
     <DisjointClasses>
+        <Class IRI="#SpatialInformationObject"/>
         <Class IRI="#SpatialObject"/>
-        <Class IRI="#SpatialRepresentationObject"/>
         <Class IRI="#Type"/>
         <Class IRI="#Value"/>
     </DisjointClasses>
     <InverseObjectProperties>
-        <ObjectProperty IRI="#refersTo"/>
         <ObjectProperty IRI="#hasContextRelation"/>
+        <ObjectProperty IRI="#refersTo"/>
     </InverseObjectProperties>
     <ObjectPropertyDomain>
         <ObjectProperty IRI="#hasAttribute"/>
-        <Class IRI="#SpatialRepresentationObject"/>
+        <Class IRI="#SpatialInformationObject"/>
     </ObjectPropertyDomain>
     <ObjectPropertyDomain>
         <ObjectProperty IRI="#hasContextRelation"/>
-        <Class IRI="#SpatialRepresentationObject"/>
+        <Class IRI="#SpatialInformationObject"/>
     </ObjectPropertyDomain>
     <ObjectPropertyDomain>
         <ObjectProperty IRI="#hasType"/>
@@ -117,7 +109,7 @@
     </ObjectPropertyDomain>
     <ObjectPropertyDomain>
         <ObjectProperty IRI="#represents"/>
-        <Class IRI="#SpatialRepresentationObject"/>
+        <Class IRI="#SpatialInformationObject"/>
     </ObjectPropertyDomain>
     <ObjectPropertyRange>
         <ObjectProperty IRI="#hasAttribute"/>
@@ -137,7 +129,7 @@
     </ObjectPropertyRange>
     <ObjectPropertyRange>
         <ObjectProperty IRI="#refersTo"/>
-        <Class IRI="#SpatialRepresentationObject"/>
+        <Class IRI="#SpatialInformationObject"/>
     </ObjectPropertyRange>
     <ObjectPropertyRange>
         <ObjectProperty IRI="#represents"/>
@@ -146,36 +138,36 @@
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#Attribute</IRI>
-        <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value.</Literal>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#ContextualizedRelation</IRI>
-        <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value. ContextualizedRelation must have exactly one Value and exactly one Type.  ContextualizedRelation refers to at least one SpatialInformationObject.</Literal>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value. ContextualizedRelation must have exactly one Value and exactly one Type.  ContextualizedRelation refers to at least one SpatialInformationObject.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#SpatialInformationObject</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">A SpatialInformationObject may have Attribute and may have ContextualizedRelation. Since Attributes and ContextualizedRelations have different descriptions in different data schema, these model classes were also chosen to work for any of the schemas used by our domain tools.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#SpatialObject</IRI>
-        <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">An InformationObject represents exactly one SpatialObject.</Literal>
-    </AnnotationAssertion>
-    <AnnotationAssertion>
-        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
-        <IRI>#SpatialRepresentationObject</IRI>
-        <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">A SpatialInformationObject may have Attribute and may have ContextualizedRelation. Since Attributes and ContextualizedRelations have different descriptions in different data schema, these model classes were also chosen to work for any of the schemas used by our domain tools.</Literal>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">An InformationObject represents exactly one SpatialObject.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#Type</IRI>
-        <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">Our use of hasType makes the model more amenable to resolving the large variation of schema differences that exist; instead of subclassing we consider types to be instances of individuals so that we are not burdened by the decision to say that something is a subtype or not. Doing so would cause more hierarchical confusion instead of help in terms of its application. Nevertheless, having typing through properties does not preclude us from adding in the function of such a hierarchy later on.</Literal>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">Our use of hasType makes the model more amenable to resolving the large variation of schema differences that exist; instead of subclassing we consider types to be instances of individuals so that we are not burdened by the decision to say that something is a subtype or not. Doing so would cause more hierarchical confusion instead of help in terms of its application. Nevertheless, having typing through properties does not preclude us from adding in the function of such a hierarchy later on.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#refersTo</IRI>
-        <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">The refersTo relation is an inverse of hasContextRelation.</Literal>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">The refersTo relation is an inverse of hasContextRelation.</Literal>
     </AnnotationAssertion>
 </Ontology>
 
 
 
-<!-- Generated by the OWL API (version 3.5.1) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 4.2.5.20160517-0735) https://github.com/owlcs/owlapi -->
 

--- a/SGA_Protege_OWL.owl
+++ b/SGA_Protege_OWL.owl
@@ -93,6 +93,43 @@
     <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute -->
 
     <owl:Class rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasType"/>
+                <owl:allValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasValue"/>
+                <owl:allValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasType"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasValue"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty>
+                    <rdf:Description>
+                        <owl:inverseOf rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasAttribute"/>
+                    </rdf:Description>
+                </owl:onProperty>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value.</rdfs:comment>
     </owl:Class>
     
@@ -101,6 +138,38 @@
     <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation -->
 
     <owl:Class rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#refersTo"/>
+                <owl:someValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasType"/>
+                <owl:allValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasValue"/>
+                <owl:allValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasType"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasValue"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">Types and Values are needed for the semantics for the same types of spatial objects are labeled differently schema to schema. Attribute must have exactly one Value and exactly one Type. It must be attached to exactly one SpatialInformationObject. Note that it is possible for two different SpatialInformationObjects to have attributes of the same Type and Value. ContextualizedRelation must have exactly one Value and exactly one Type.  ContextualizedRelation refers to at least one SpatialInformationObject.</rdfs:comment>
     </owl:Class>
     
@@ -109,6 +178,31 @@
     <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject -->
 
     <owl:Class rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasAttribute"/>
+                <owl:allValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasContextRelation"/>
+                <owl:allValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#represents"/>
+                <owl:allValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#represents"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A SpatialInformationObject may have Attribute and may have ContextualizedRelation. Since Attributes and ContextualizedRelations have different descriptions in different data schema, these model classes were also chosen to work for any of the schemas used by our domain tools.</rdfs:comment>
     </owl:Class>
     
@@ -144,6 +238,45 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    <owl:Restriction>
+        <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasAttribute"/>
+        <owl:someValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
+        <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+    </owl:Restriction>
+    <owl:Restriction>
+        <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasContextRelation"/>
+        <owl:someValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+        <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+    </owl:Restriction>
+    <owl:Restriction>
+        <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasType"/>
+        <owl:someValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Type"/>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
+                    <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+    </owl:Restriction>
+    <owl:Restriction>
+        <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasValue"/>
+        <owl:someValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
+                    <rdf:Description rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+    </owl:Restriction>
+    <owl:Restriction>
+        <owl:onProperty rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#represents"/>
+        <owl:someValuesFrom rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject"/>
+        <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
+    </owl:Restriction>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">

--- a/SGA_Protege_OWL.owl
+++ b/SGA_Protege_OWL.owl
@@ -23,10 +23,7 @@
 
     <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasAttribute -->
 
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasAttribute">
-        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
-        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
-    </owl:ObjectProperty>
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasAttribute"/>
     
 
 
@@ -34,8 +31,6 @@
 
     <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasContextRelation">
         <owl:inverseOf rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#refersTo"/>
-        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
-        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
     </owl:ObjectProperty>
     
 
@@ -52,19 +47,13 @@
 
     <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasValue -->
 
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasValue">
-        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Attribute"/>
-        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
-        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#Value"/>
-    </owl:ObjectProperty>
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#hasValue"/>
     
 
 
     <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#refersTo -->
 
     <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#refersTo">
-        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#ContextualizedRelation"/>
-        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
         <rdfs:comment xml:lang="en">The refersTo relation is an inverse of hasContextRelation.</rdfs:comment>
     </owl:ObjectProperty>
     
@@ -72,10 +61,7 @@
 
     <!-- http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#represents -->
 
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#represents">
-        <rdfs:domain rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialInformationObject"/>
-        <rdfs:range rdf:resource="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#SpatialObject"/>
-    </owl:ObjectProperty>
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/holly2012/ontologies/2016/SGA_Pattern#represents"/>
     
 
 


### PR DESCRIPTION
What I've done:
- modified class disjointness to use AllDisjointClasses axiom (which is equivalent to pairwise disjointness axioms)
- Change the file format of the OWL file from OWL/XML into RDF/XML --- the latter is more common and also compatible with RDF-based tools.
- Added all axioms from the paper.
- Removed all (unscoped) domain and range restrictions of properties -- the scoped version of those restrictions are in the paper, and thus have been added to the ontology, except for the refersTo property whose domain and range restrictions are implicit as it is the inverse of hasContextRelation.
